### PR TITLE
Add password to user on admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -16,8 +16,9 @@ class UserAdmin(admin.ModelAdmin):
         'zipcode',
         'active',
         'phonenumber',
+        'password',
     )
-    exclude= ('slug', 'password',)
+    exclude= ('slug', )
 
 admin.site.register(TrackerGroup)
 admin.site.register(Question)


### PR DESCRIPTION
When creating user's under my group, I realized I couldn't create passwords for my users so I could not log in as my user to test some pages.
