### PR TITLE
Remove edit button from answer page

### DIFF
--- a/core/templates/core/answer_detail.html
+++ b/core/templates/core/answer_detail.html
@@ -5,7 +5,5 @@
 <h3>Associated Tracker: <a href="{{answer.question.tracker.get_absolute_url}}">{{answer.question.tracker}}</a></h3>
 <h3>Associated Queston: <a href="{{answer.question.get_absolute_url}}">{{answer.question.description}}</a></h3>
 <h3>Answer: {{answer.name}}</h3>
-<a href="{% url 'answer_edit' user.pk %}">
-            <button type='submit'>Edit Answer</button>
-        </a>
+
 {% endblock %}


### PR DESCRIPTION
The edit feature is no longer going to be used, and therefore the button was directing to a place that isn't available. Removed button to fix URL error.
